### PR TITLE
Removing the 2019 hard coding and making it a bit configurable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,29 @@ module ApplicationHelper
 		link_to( content_tag( 'span', 'CSV' ), url, :title => title, :class => 'csv' ) + content_tag( 'label', title )
   end
 
+  def election_lists_of_links
+    content = ""
+
+    general_election_links = relevant_general_elections.pluck(:id, :polling_on).map do |id, polling_on|
+      link_to(polling_on.year, general_election_party_list_path(id))
+    end
+  end
+
+  def output_election_lists_of_links
+    sanitize election_lists_of_links.to_sentence
+  end
+
+  def output_election_years
+    relevant_general_elections.pluck(:polling_on).map do |polling_on|
+      polling_on.year
+    end.to_sentence(last_word_connector: ' or ')
+  end
+
+  def relevant_general_elections
+    GeneralElection.where(is_notional: false).where("EXTRACT(YEAR FROM polling_on) <= #{end_year}").order(:polling_on)
+  end
+
+  def end_year
+    ENV.fetch('LATEST_ELECTION_YEAR', 2019)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,8 +5,6 @@ module ApplicationHelper
   end
 
   def election_lists_of_links
-    content = ""
-
     general_election_links = relevant_general_elections.pluck(:id, :polling_on).map do |id, polling_on|
       link_to(polling_on.year, general_election_party_list_path(id))
     end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
 
 <p>We publish <a href="https://commonslibrary.parliament.uk/topic/parliament-and-elections/elections-elections/">briefing papers</a> including more detailed analysis of election results.</p>
 
-<p>The site includes data for the <a href="/general-elections/1/political-parties">2010</a>, <a href="/general-elections/2/political-parties">2015</a>, <a href="/general-elections/3/political-parties">2017</a> and <a href="/general-elections/4/political-parties">2019</a> general elections. We plan to add to this, including data for earlier general elections and by-elections.</p>
+<p>The site includes data for the <%= output_election_lists_of_links %> general elections. We plan to add to this, including data for earlier general elections and by-elections.</p>
 
 <p>As well as <a href="/general-elections">general election</a> data, the site includes tables for:
 

--- a/app/views/member/show.html.erb
+++ b/app/views/member/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= content_tag( 'p', link_to( "Parliament Member page for #{@member.display_name}", "https://members.parliament.uk/member/#{@member.mnis_id}" ) ) %>
 
-<%= content_tag( 'p', "Elections listed as contested and won are those held during the general elections of 2010, 2015, 2017 or 2019. A person may have contested or contested and won other elections." ) %>
+<%= content_tag( 'p', "Elections listed as contested and won are those held during the general elections of #{output_election_years}. A person may have contested or contested and won other elections." ) %>
 
 
 

--- a/app/views/member_election/index.html.erb
+++ b/app/views/member_election/index.html.erb
@@ -2,8 +2,9 @@
 
 <%= content_tag( 'p', link_to( "Parliament Member page for #{@member.display_name}", "https://members.parliament.uk/member/#{@member.mnis_id}" ) ) %>
 
-<%= content_tag( 'p', "Elections listed as contested and won are those forming part of the general elections in 2010, 2015, 2017 or 2019. A person may have contested or contested and won an election outside this grouping." ) %>
+<%= content_tag( 'p', "Elections listed as contested and won are those forming part of the general elections in #{output_election_years}. A person may have contested or contested and won an election outside this grouping." ) %>
 
+WOOF
 
 
 <%= render :partial => 'election', :collection => @elections, :locals => { :member => @member } %>

--- a/app/views/member_election/won.html.erb
+++ b/app/views/member_election/won.html.erb
@@ -2,6 +2,6 @@
 
 <%= content_tag( 'p', link_to( "Parliament Member page for #{@member.display_name}", "https://members.parliament.uk/member/#{@member.mnis_id}" ) ) %>
 
-<%= content_tag( 'p', "Elections listed as contested and won are those forming part of the general elections in 2010, 2015, 2017 or 2019. A person may have contested or contested and won an election outside this grouping." ) %>
+<%= content_tag( 'p', "Elections listed as contested and won are those forming part of the general elections in #{output_election_years}. A person may have contested or contested and won an election outside this grouping." ) %>
 
 <%= render :partial => 'election', :collection => @elections_won, :locals => { :member => @member } %>

--- a/app/views/meta/coverage.html.erb
+++ b/app/views/meta/coverage.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag( 'p', "This website provides result data for the general elections for #{link_to( '2010', general_election_party_list_url( :general_election => 1 ) )}, #{link_to( '2015', general_election_party_list_url( :general_election => 2 ) )}, #{link_to( '2017', general_election_party_list_url( :general_election => 3 ) )} and #{link_to( '2019', general_election_party_list_url( :general_election => 4 ) )}.".html_safe ) %>
+<%= content_tag( 'p', "This website provides result data for the general elections for #{output_election_lists_of_links}".html_safe ) %>
 
 <%= content_tag( 'p', "It also provides predicted or ‘notional’ results of the 2019 general election. These results are shown as if that election had been held according to the upcoming constituency boundaries. " ) %>
 

--- a/app/views/meta/roadmap.html.erb
+++ b/app/views/meta/roadmap.html.erb
@@ -11,7 +11,7 @@
 <%= content_tag( 'h2', "What we're working on" ) %>
 
 <ul>
-	<%= content_tag( 'li', 'Adding by-election results for the 2010, 2015, 2017 and 2019 Parliaments.' ) %>
+	<%= content_tag( 'li', "Adding by-election results for the #{output_election_years} Parliaments." ) %>
 	<%= content_tag( 'li', 'Post-launch usability improvements.' ) %>
 </ul>
 


### PR DESCRIPTION
An example of how we could make the 2019 latest election year configurable.. for now.

It does add the GE query, but rails will cache it and it's a very cheap one.