### PR TITLE
Beef up rack attack cloudflare protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 8.0"
 
 # For controlling access
 gem 'rack-attack'
+gem 'cloudflare-rails'
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cloudflare-rails (6.2.0)
+      actionpack (>= 7.1.0, < 8.1.0)
+      activesupport (>= 7.1.0, < 8.1.0)
+      railties (>= 7.1.0, < 8.1.0)
+      zeitwerk (>= 2.5.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -129,7 +134,6 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
     minitest (5.25.5)
     msgpack (1.8.0)
     net-imap (0.5.8)
@@ -142,9 +146,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.8)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
@@ -265,7 +266,6 @@ GEM
 
 PLATFORMS
   arm64-darwin
-  ruby
   x86_64-darwin
   x86_64-linux
 
@@ -275,6 +275,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara
+  cloudflare-rails
   csv
   debug
   fiddle

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,25 +1,5 @@
-class Rack::Attack
-  # class Request < ::Rack::Request
-  #   # Create a remote_ip method for a rack request by setting it to the Cloudflare connecting ip header.
-  #   # To restore original visitor IP addresses at your origin web server, Cloudflare recommends your logs or applications look at CF-Connecting-IP instead of X-Forwarded-For, since CF-Connecting-IP has a consistent format containing only one IP.
-  #   # https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-CloudFlare-handle-HTTP-Request-headers-
-  #   def remote_ip
-  #     @remote_ip ||= (env['HTTP_CF_CONNECTING_IP'] || ip).to_s
-  #   end
-
-  #   # This checks the request IP against the Cloudflare IP ranges and the action dispatch default trusted proxies.
-  #   # These include various local IPs like 127.0.0.1 so that local requests won't be blocked.
-  #   def proxied?
-  #     Rails.application.config.action_dispatch.trusted_proxies.any? { |range| range === ip }
-  #   end
-  # end
-
-  # # Block all requests coming from non-Cloudflare IPs.
-  # blocklist(" block non-proxied requests in production" ) do |request|
-  #   if request.proxied?
-  #     false
-  #   else
-  #     true if FEATURE_LIMIT_TO_CLOUDFLARE
-  #   end
-  # end
+if Rails.env.production? && !ENV["SWITCH_OFF_RACK_ATTACK"]
+  Rack::Attack.blocklist('CloudFlare WAF bypass') do |req|
+    !req.cloudflare?
+  end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,25 +1,25 @@
 class Rack::Attack
-  class Request < ::Rack::Request
-    # Create a remote_ip method for a rack request by setting it to the Cloudflare connecting ip header.
-    # To restore original visitor IP addresses at your origin web server, Cloudflare recommends your logs or applications look at CF-Connecting-IP instead of X-Forwarded-For, since CF-Connecting-IP has a consistent format containing only one IP.
-    # https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-CloudFlare-handle-HTTP-Request-headers-
-    def remote_ip
-      @remote_ip ||= (env['HTTP_CF_CONNECTING_IP'] || ip).to_s
-    end
+  # class Request < ::Rack::Request
+  #   # Create a remote_ip method for a rack request by setting it to the Cloudflare connecting ip header.
+  #   # To restore original visitor IP addresses at your origin web server, Cloudflare recommends your logs or applications look at CF-Connecting-IP instead of X-Forwarded-For, since CF-Connecting-IP has a consistent format containing only one IP.
+  #   # https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-CloudFlare-handle-HTTP-Request-headers-
+  #   def remote_ip
+  #     @remote_ip ||= (env['HTTP_CF_CONNECTING_IP'] || ip).to_s
+  #   end
 
-    # This checks the request IP against the Cloudflare IP ranges and the action dispatch default trusted proxies.
-    # These include various local IPs like 127.0.0.1 so that local requests won't be blocked.
-    def proxied?
-      Rails.application.config.action_dispatch.trusted_proxies.any? { |range| range === ip }
-    end
-  end
+  #   # This checks the request IP against the Cloudflare IP ranges and the action dispatch default trusted proxies.
+  #   # These include various local IPs like 127.0.0.1 so that local requests won't be blocked.
+  #   def proxied?
+  #     Rails.application.config.action_dispatch.trusted_proxies.any? { |range| range === ip }
+  #   end
+  # end
 
-  # Block all requests coming from non-Cloudflare IPs.
-  blocklist(" block non-proxied requests in production" ) do |request|
-    if request.proxied?
-      false
-    else
-      true if FEATURE_LIMIT_TO_CLOUDFLARE
-    end
-  end
+  # # Block all requests coming from non-Cloudflare IPs.
+  # blocklist(" block non-proxied requests in production" ) do |request|
+  #   if request.proxied?
+  #     false
+  #   else
+  #     true if FEATURE_LIMIT_TO_CLOUDFLARE
+  #   end
+  # end
 end


### PR DESCRIPTION
The Cloudflare rails gem maintains a list of Cloudflare IP addresses and combined with Rack Attack can be used to block all traffic which is not routed via Cloudflare.
