### PR TITLE
tidy-party-names-in-result-summaries

### DIFF
--- a/lib/tasks/live/36-remove-cooperative-party-from-result-summaries/remove-cooperative-party-from-result-summaries.rake
+++ b/lib/tasks/live/36-remove-cooperative-party-from-result-summaries/remove-cooperative-party-from-result-summaries.rake
@@ -1,0 +1,47 @@
+# ## A task to remove the Co-operative party from result summaries.
+task :remove_cooperative_party_from_result_summaries => :environment do
+  puts "removing the cooperative party from result summaries"
+  
+  # We know that the result summary with ID 21 is 'Conservative gain from Labour Co-operative' ...
+  # ... and that the result summary with ID 13 is 'Conservative gain from Labour'.
+  # We find any election with a result summary ID of 21.
+  elections = Election.where( 'result_summary_id = ?', 21 )
+  
+  # For each election with a result summary ID of 21 ...
+  elections.each do |election|
+  
+    # ... we set the result summary ID to 13 ...
+    election.result_summary_id = 13
+    
+    # ... and save the election.
+    election.save!
+  end
+  
+  # We know that the result summary with ID 19 is 'SNP gain from Labour Co-operative' ...
+  # ... and that the result summary with ID 3 is 'SNP gain from Labour'.
+  # We find any election with a result summary ID of 19.
+  elections = Election.where( 'result_summary_id = ?', 19 )
+  
+  # For each election with a result summary ID of 19 ...
+  elections.each do |election|
+  
+    # ... we set the result summary ID to 3 ...
+    election.result_summary_id = 3
+    
+    # ... and save the election.
+    election.save!
+  end
+  
+  # We find the result summary with ID 21 ...
+  result_summary = ResultSummary.find ( 21 )
+  
+  # ... and destroy it.
+  result_summary.destroy!
+  
+  # We find the result summary with ID 19 ...
+  result_summary = ResultSummary.find ( 19 )
+  
+  # ... and destroy it.
+  result_summary.destroy!
+end
+

--- a/lib/tasks/live/37-sort-result-summary-party-names/sort-result-summary-party-names.rake
+++ b/lib/tasks/live/37-sort-result-summary-party-names/sort-result-summary-party-names.rake
@@ -1,0 +1,106 @@
+# ## A task to sort party names in result summaries.
+task :sort_party_names_in_result_summaries => :environment do
+  puts "sorting party names in result summaries"
+  
+  # We get all result summaries.
+  result_summaries = ResultSummary.all
+  
+  # For each result summary ...
+  result_summaries.each do |result_summary|
+  
+    # We create a string to hold the new summary text.
+    new_summary_text = ''
+  
+    # ... if the result summary summary text includes ' gain from ' ...
+    if result_summary.summary.include?( ' gain from ' )
+    
+      # ... if the result summary is to the Speaker ...
+      if result_summary.is_to_commons_speaker
+      
+        # ... we set the new result summary text to include 'Speaker'.
+        new_summary_text = 'Speaker'
+    
+      # Otherwise, if the result summary is to an independent ...
+      elsif result_summary.is_to_independent
+      
+        # ... we set the new result summary text to include 'Independent'.
+        new_summary_text = 'Independent'
+      
+      # Otherwise, the result summary must be to a party ...
+      else
+      
+        # ... so we find the party ...
+        political_party = PoliticalParty.find( result_summary.to_political_party_id )
+        
+        # ... and set the new result summary text to include the party name.
+        new_summary_text = political_party.name
+      end
+      
+      # We append the text ' gain from ' to the new summary text.
+      new_summary_text += ' gain from '
+      
+      # If the result summary is from the Speaker ...
+      if result_summary.is_from_commons_speaker
+      
+        # ... we append 'Speaker' to the new result summary text.
+        new_summary_text += 'Speaker'
+    
+      # Otherwise, if the result summary is from an independent ...
+      elsif result_summary.is_from_independent
+      
+        # ... we append 'Independent' to the new result summary text.
+        new_summary_text += 'Independent'
+      
+      # Otherwise, the result summary must be from a party ...
+      else
+      
+        # ... so we find the party ...
+        political_party = PoliticalParty.find( result_summary.from_political_party_id )
+        
+        # ... and append the party name to the new result summary text.
+        new_summary_text += political_party.name
+      end
+      
+    # Otherwise, if the result summary summary text includes ' hold' ...
+    elsif result_summary.summary.include?( ' hold' )
+    
+      # ... if the result summary is from the Speaker ...
+      if result_summary.is_from_commons_speaker
+      
+        # ... we set the new result summary text to 'Speaker hold'.
+        new_summary_text = 'Speaker hold'
+    
+      # Otherwise, if the result summary is from an independent ...
+      elsif result_summary.is_from_independent
+      
+        # ... we set the new result summary text to 'Independent hold'.
+        new_summary_text = 'Independent hold'
+      
+      # Otherwise, the result summary must be from a party ...
+      else
+      
+        # ... so we find the party ...
+        political_party = PoliticalParty.find( result_summary.from_political_party_id )
+        
+        # ... and set the new result summary text to 'party name hold'.
+        new_summary_text = political_party.name + ' hold'
+      end
+    
+    # Otherwise, if the result summary summary text includes neither ' gain from ' nor ' hold' ...
+    else
+    
+      # ... we flag that something has gone wrong.
+      puts "result summary summary text includes neither ' gain from ' nor ' hold'"
+    end
+    
+    # If the result summary summary text has changed ...
+    if new_summary_text != result_summary.summary
+    
+      # ... we set the summary of the result summary to new text ...
+      result_summary.summary = new_summary_text
+      
+      # ... and save the result summary.
+      result_summary.save!
+    end
+  end
+end


### PR DESCRIPTION
- **new script to remove the co-operative party from result summaries**
- **new rake task to populate result summary summary text with latest party names**
